### PR TITLE
gitsecure auto-remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM shri4u/myapp-base:0.1
 RUN apt-get update --fix-missing && apt-get install -y --fix-missing \
     pkg-config libreadline-dev libxml2-dev
+   
 
 WORKDIR /app
 COPY requirements.txt /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ importlib-metadata==0.18
 jsonschema==3.0.1
 six==1.12.0
 zipp==0.5.2
-feedgen==0.8.0
-validators==0.12.2
-colander==1.2
+feedgen==0.9.0
+validators==0.12.6
+colander==1.7.0
+django==1.11.28


### PR DESCRIPTION
# GitSecure Vulnerablility Report

| Control ID | Section | Description |
|------------|---------|-------------|
| RA-5 | Risk Assessment | Vulnerability Scanning |
| CA-7 | Security Assessment and Authorization | Continuous Monitoring |
| SA-12 | System and Services Acquisition | Supply Chain Protection |
| SI-2 | System and Information Integrity | Flaw Remediation |
| CM-4 | Configuration Management | Security Impact Analysis |
| CA-2 | Security Assessment and Authorization | Security Assessments |

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/Dockerfile <strong> Stage: </strong>shri4u/myapp-base:0.1
  </summary> 

:white_check_mark: OS Packages Safe 
:x: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>
<p>
<details>
<summary> Package Name: feedgen | Current Version: 0.8.0  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 0.9.0 

**CVE** : CVE-2020-5227 
**Severity** : HIGH 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2020-5227 
**Description** : ### Impact

The *feedgen* library allows supplying XML as content for some of the available fields. This XML will be parsed and integrated into the existing XML tree. During this process, feedgen is vulnerable to [XML Denial of Service Attacks](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses) (e.g. XML Bomb).

This becomes a concern in particular if feedgen is used to include content from untrused sources and if XML (including XHTML) is directly included instead of providing plain tex content only.

### Patches

This problem has been fixed in feedgen 0.9.0 which disallows XML entity expansion and external resources.

### Workarounds

Updating is strongly recommended and should not be problematic. Nevertheless, as a workaround, avoid providing XML directly to feedgen or ensure that no entity expansion is part of the XML. 

### References

- [Security Briefs - XML Denial of Service Attacks and Defenses](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses)
- [Billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack#cite_note-2)

### For more information

If you have any questions or comments about this advisory:
- Open an issue in [lkiesow/python-feedgen](https://github.com/lkiesow/python-feedgen/issues)
- Send an email to security@lkiesow.de 


**CVE** : GHSA-g8q7-xv52-hf9f 
**Severity** : HIGH 
**Link** : https://github.com/lkiesow/python-feedgen/security/advisories/GHSA-g8q7-xv52-hf9f 
**Description** : ### Impact

The *feedgen* library allows supplying XML as content for some of the available fields. This XML will be parsed and integrated into the existing XML tree. During this process, feedgen is vulnerable to [XML Denial of Service Attacks](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses) (e.g. XML Bomb).

This becomes a concern in particular if feedgen is used to include content from untrused sources and if XML (including XHTML) is directly included instead of providing plain tex content only.

### Patches

This problem has been fixed in feedgen 0.9.0 which disallows XML entity expansion and external resources.

### Workarounds

Updating is strongly recommended and should not be problematic. Nevertheless, as a workaround, avoid providing XML directly to feedgen or ensure that no entity expansion is part of the XML. 

### References

- [Security Briefs - XML Denial of Service Attacks and Defenses](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses)
- [Billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack#cite_note-2)

### For more information

If you have any questions or comments about this advisory:
- Open an issue in [lkiesow/python-feedgen](https://github.com/lkiesow/python-feedgen/issues)
- Send an email to security@lkiesow.de 


</details>
</p>

<p>
<details>
<summary> Package Name: colander | Current Version: 1.2  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 1.7.0 

**CVE** : CVE-2017-18361 
**Severity** : LOW 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2017-18361 
**Description** : In Pylons Colander through 1.6, the URL validator allows an attacker to potentially cause an infinite loop thereby causing a denial of service via an unclosed parenthesis. 


**CVE** : GHSA-rv95-4wxj-6fqq 
**Severity** : LOW 
**Link** :  
**Description** : In Pylons Colander through 1.6, the URL validator allows an attacker to potentially cause an infinite loop thereby causing a denial of service via an unclosed parenthesis. 


</details>
</p>

<p>
<details>
<summary> Package Name: django | Current Version: 1.2  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 1.11.28 

**CVE** : CVE-2010-3082 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2010-3082 
**Description** : Cross-site scripting (XSS) vulnerability in Django 1.2.x before 1.2.2 allows remote attackers to inject arbitrary web script or HTML via a csrfmiddlewaretoken (aka csrf_token) cookie. 


**CVE** : GHSA-fxpg-gg9g-76gj 
**Severity** : MODERATE 
**Link** :  
**Description** : Cross-site scripting (XSS) vulnerability in Django 1.2.x before 1.2.2 allows remote attackers to inject arbitrary web script or HTML via a csrfmiddlewaretoken (aka csrf_token) cookie. 


**CVE** : CVE-2011-4136 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-4136 
**Description** : django.contrib.sessions in Django before 1.2.7 and 1.3.x before 1.3.1, when session data is stored in the cache, uses the root namespace for both session identifiers and application-data keys, which allows remote attackers to modify a session by triggering use of a key that is equal to that session's identifier. 


**CVE** : GHSA-x88j-93vc-wpmp 
**Severity** : MODERATE 
**Link** :  
**Description** : django.contrib.sessions in Django before 1.2.7 and 1.3.x before 1.3.1, when session data is stored in the cache, uses the root namespace for both session identifiers and application-data keys, which allows remote attackers to modify a session by triggering use of a key that is equal to that session's identifier. 


**CVE** : CVE-2011-0698 
**Severity** : HIGH 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-0698 
**Description** : Directory traversal vulnerability in Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 on Windows might allow remote attackers to read or execute files via a / (slash) character in a key in a session cookie, related to session replays. 


**CVE** : GHSA-7g9h-c88w-r7h2 
**Severity** : HIGH 
**Link** :  
**Description** : Directory traversal vulnerability in Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 on Windows might allow remote attackers to read or execute files via a / (slash) character in a key in a session cookie, related to session replays. 


**CVE** : CVE-2010-4535 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2010-4535 
**Description** : The password reset functionality in django.contrib.auth in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not validate the length of a string representing a base36 timestamp, which allows remote attackers to cause a denial of service (resource consumption) via a URL that specifies a large base36 integer. 


**CVE** : GHSA-7wph-fc4w-wqp2 
**Severity** : MODERATE 
**Link** :  
**Description** : The password reset functionality in django.contrib.auth in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not validate the length of a string representing a base36 timestamp, which allows remote attackers to cause a denial of service (resource consumption) via a URL that specifies a large base36 integer. 


**CVE** : CVE-2010-4534 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2010-4534 
**Description** : The administrative interface in django.contrib.admin in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not properly restrict use of the query string to perform certain object filtering, which allows remote authenticated users to obtain sensitive information via a series of requests containing regular expressions, as demonstrated by a created_by__password__regex parameter. 


**CVE** : GHSA-fwr5-q9rx-294f 
**Severity** : MODERATE 
**Link** :  
**Description** : The administrative interface in django.contrib.admin in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not properly restrict use of the query string to perform certain object filtering, which allows remote authenticated users to obtain sensitive information via a series of requests containing regular expressions, as demonstrated by a created_by__password__regex parameter. 


**CVE** : CVE-2011-4137 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-4137 
**Description** : The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 relies on Python libraries that attempt access to an arbitrary URL with no timeout, which allows remote attackers to cause a denial of service (resource consumption) via a URL associated with (1) a slow response, (2) a completed TCP connection with no application data sent, or (3) a large amount of application data, a related issue to CVE-2011-1521. 


**CVE** : GHSA-3jqw-crqj-w8qw 
**Severity** : MODERATE 
**Link** :  
**Description** : The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 relies on Python libraries that attempt access to an arbitrary URL with no timeout, which allows remote attackers to cause a denial of service (resource consumption) via a URL associated with (1) a slow response, (2) a completed TCP connection with no application data sent, or (3) a large amount of application data, a related issue to CVE-2011-1521. 


**CVE** : CVE-2011-4140 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-4140 
**Description** : The CSRF protection mechanism in Django through 1.2.7 and 1.3.x through 1.3.1 does not properly handle web-server configurations supporting arbitrary HTTP Host headers, which allows remote attackers to trigger unauthenticated forged requests via vectors involving a DNS CNAME record and a web page containing JavaScript code. 


**CVE** : GHSA-h95j-h2rv-qrg4 
**Severity** : MODERATE 
**Link** :  
**Description** : The CSRF protection mechanism in Django through 1.2.7 and 1.3.x through 1.3.1 does not properly handle web-server configurations supporting arbitrary HTTP Host headers, which allows remote attackers to trigger unauthenticated forged requests via vectors involving a DNS CNAME record and a web page containing JavaScript code. 


**CVE** : CVE-2011-0696 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-0696 
**Description** : Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 does not properly validate HTTP requests that contain an X-Requested-With header, which makes it easier for remote attackers to conduct cross-site request forgery (CSRF) attacks via forged AJAX requests that leverage a "combination of browser plugins and redirects," a related issue to CVE-2011-0447. 


**CVE** : GHSA-5j2h-h5hg-3wf8 
**Severity** : MODERATE 
**Link** :  
**Description** : Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 does not properly validate HTTP requests that contain an X-Requested-With header, which makes it easier for remote attackers to conduct cross-site request forgery (CSRF) attacks via forged AJAX requests that leverage a "combination of browser plugins and redirects," a related issue to CVE-2011-0447. 


**CVE** : CVE-2011-0697 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2011-0697 
**Description** : Cross-site scripting (XSS) vulnerability in Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 might allow remote attackers to inject arbitrary web script or HTML via a filename associated with a file upload. 


**CVE** : GHSA-8m3r-rv5g-fcpq 
**Severity** : MODERATE 
**Link** :  
**Description** : Cross-site scripting (XSS) vulnerability in Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 might allow remote attackers to inject arbitrary web script or HTML via a filename associated with a file upload. 


**CVE** : CVE-2019-3498 
**Severity** : LOW 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2019-3498 
**Description** : In Django 1.11.x before 1.11.18, 2.0.x before 2.0.10, and 2.1.x before 2.1.5, an Improper Neutralization of Special Elements in Output Used by a Downstream Component issue exists in django.views.defaults.page_not_found(), leading to content spoofing (in a 404 error page) if a user fails to recognize that a crafted URL has malicious content. 


**CVE** : GHSA-337x-4q8g-prc5 
**Severity** : LOW 
**Link** :  
**Description** : In Django 1.11.x before 1.11.18, 2.0.x before 2.0.10, and 2.1.x before 2.1.5, an Improper Neutralization of Special Elements in Output Used by a Downstream Component issue exists in django.views.defaults.page_not_found(), leading to content spoofing (in a 404 error page) if a user fails to recognize that a crafted URL has malicious content. 


**CVE** : CVE-2019-6975 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2019-6975 
**Description** : Django 1.11.x before 1.11.19, 2.0.x before 2.0.11, and 2.1.x before 2.1.6 allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the django.utils.numberformat.format() function. 


**CVE** : GHSA-wh4h-v3f2-r2pp 
**Severity** : MODERATE 
**Link** :  
**Description** : Django 1.11.x before 1.11.19, 2.0.x before 2.0.11, and 2.1.x before 2.1.6 allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the django.utils.numberformat.format() function. 


**CVE** : CVE-2015-5143 
**Severity** : HIGH 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2015-5143 
**Description** : The session backends in Django before 1.4.21, 1.5.x through 1.6.x, 1.7.x before 1.7.9, and 1.8.x before 1.8.3 allows remote attackers to cause a denial of service (session store consumption) via multiple requests with unique session keys. 


**CVE** : GHSA-h582-2pch-3xv3 
**Severity** : HIGH 
**Link** :  
**Description** : The session backends in Django before 1.4.21, 1.5.x through 1.6.x, 1.7.x before 1.7.9, and 1.8.x before 1.8.3 allows remote attackers to cause a denial of service (session store consumption) via multiple requests with unique session keys. 


**CVE** : CVE-2019-19844 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2019-19844 
**Description** : Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover. A suitably crafted email address (that is equal to an existing user's email address after case transformation of Unicode characters) would allow an attacker to be sent a password reset token for the matched user account. (One mitigation in the new releases is to send password reset tokens only to the registered user email address.) 


**CVE** : GHSA-vfq6-hq5r-27r6 
**Severity** : MODERATE 
**Link** :  
**Description** : Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover. A suitably crafted email address (that is equal to an existing user's email address after case transformation of Unicode characters) would allow an attacker to be sent a password reset token for the matched user account. (One mitigation in the new releases is to send password reset tokens only to the registered user email address.) 


**CVE** : CVE-2020-7471 
**Severity** : MODERATE 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2020-7471 
**Description** : Django 1.11 before 1.11.28, 2.2 before 2.2.10, and 3.0 before 3.0.3 allows SQL Injection if untrusted data is used as a StringAgg delimiter (e.g., in Django applications that offer downloads of data as a series of rows with a user-specified column delimiter). By passing a suitably crafted delimiter to a contrib.postgres.aggregates.StringAgg instance, it was possible to break escaping and inject malicious SQL. 


**CVE** : GHSA-hmr4-m2h5-33qx 
**Severity** : MODERATE 
**Link** :  
**Description** : Django 1.11 before 1.11.28, 2.2 before 2.2.10, and 3.0 before 3.0.3 allows SQL Injection if untrusted data is used as a StringAgg delimiter (e.g., in Django applications that offer downloads of data as a series of rows with a user-specified column delimiter). By passing a suitably crafted delimiter to a contrib.postgres.aggregates.StringAgg instance, it was possible to break escaping and inject malicious SQL. 


</details>
</p>

<p>
<details>
<summary> Package Name: validators | Current Version: 0.12.2  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 0.12.6 

**CVE** : CVE-2019-19588 
**Severity** : HIGH 
**Link** : https://nvd.nist.gov/vuln/detail/CVE-2019-19588 
**Description** : The validators package 0.12.2 through 0.12.5 for Python enters an infinite loop when validators.domain is called with a crafted domain string. This is fixed in 0.12.6. 


**CVE** : GHSA-5qcg-w2cc-xffw 
**Severity** : HIGH 
**Link** :  
**Description** : The validators package 0.12.2 through 0.12.5 for Python enters an infinite loop when validators.domain is called with a crafted domain string. This is fixed in 0.12.6. 


</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

